### PR TITLE
Use mysql version 5.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
 
     chimera:
         image: bptlab/chimera:dev
-        ports:
-            - 8081:8080
         environment:
             - CHIMERA_DEPLOY_NAME=Chimera
             - CHIMERA_DB_HOST=database
@@ -24,8 +22,6 @@ services:
         image: bptlab/unicorn:dev
         volumes:
             - ./server-config.xml:/usr/local/tomcat/conf/server-template.xml
-        ports:
-            - 8082:8080
         environment:
             - UNICORN_DEPLOY_NAME=Unicorn
             - UNICORN_DB_HOST=database
@@ -36,8 +32,6 @@ services:
             - UNICORN_DB_TEST_DB=eap_testing
     gryphon:
         image: bptlab/gryphon:dev
-        ports:
-            - 8083:3000
         volumes:
             - gryphon-mongodb-data:/var/lib/mongodb
     database:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,10 +36,12 @@ services:
             - UNICORN_DB_TEST_DB=eap_testing
     gryphon:
         image: bptlab/gryphon:dev
+        ports:
+            - 8083:3000
         volumes:
             - gryphon-mongodb-data:/var/lib/mongodb
     database:
-        image: mysql:latest
+        image: mysql:5.7
         volumes:
             - mysql-data:/var/lib/mysql
             - ./mysql-init:/docker-entrypoint-initdb.d

--- a/nginx-config.conf
+++ b/nginx-config.conf
@@ -8,13 +8,16 @@ http {
     }
 
     server {
+        rewrite ^/Chimera$ $scheme://$http_host/Chimera/ permanent;
         location /Chimera {
             proxy_pass http://chimera:8080;
         }
 
+        rewrite ^/Unicorn$ $scheme://$http_host/Unicorn/ permanent;
         location /Unicorn {
             proxy_pass http://unicorn:8080;
         }
+
         rewrite ^/gryphon$ $scheme://$http_host/gryphon/ permanent;
         location /gryphon/ {
             proxy_pass http://gryphon:3000/;

--- a/nginx-config.conf
+++ b/nginx-config.conf
@@ -15,7 +15,8 @@ http {
         location /Unicorn {
             proxy_pass http://unicorn:8080;
         }
-        location /gryphon {
+        rewrite ^/gryphon$ $scheme://$http_host/gryphon/ permanent;
+        location /gryphon/ {
             proxy_pass http://gryphon:3000/;
         }
     }


### PR DESCRIPTION
## Bug:
1. Chimera and Unicorn did not start properly. The backend could not connect to the database.  It failed with 
```Unable to load authentication plugin 'caching_sha2_password'```.
1. Gryphon is not not accessible via the proxy (for me). The locations of the requested ressources (css, js files) are not correctly set (no base url `/gryphon`). This is a defect in [Gryphon](https://github.com/bptlab/gryphon).
## Mitigation:
1. Use `mysql:5.7` as database image. The plugin was introduced as default in `mysql:8` and cannot be used in the current Chimera configuration.
1. Expose gryphon port 3000 for direct access in order to bypass proxy