### PR TITLE
Use Docker hostnames as the callback URLs

### DIFF
--- a/host.env
+++ b/host.env
@@ -5,7 +5,7 @@ DEPLOY_PATH=/
 CHIMERA_DEPLOY_NAME=chimera
 # unicorn reachable for chimera:
 # address of unicorn host
-UNICORN_URL=https://bpt-lab.org
+UNICORN_URL=http://unicorn:8080
 # path of hosted unicorn (with leading shlash)
 UNICORN_DEPLOY_PATH=/unicorn
 
@@ -16,5 +16,5 @@ UNICORN_DEPLOY_NAME=unicorn
 GRYPHON_DEPLOY_NAME=gryphon
 
 # URL/Path of deployed chimera (used for callback from Unicorn, deploy path with slash)
-CHIMERA_URL=https://bpt-lab.org
+CHIMERA_URL=http://chimera:8080
 CHIMERA_DEPLOY_PATH=/chimera

--- a/host.env
+++ b/host.env
@@ -6,7 +6,7 @@ CHIMERA_DEPLOY_NAME=chimera
 # unicorn reachable for chimera:
 # address of unicorn host
 UNICORN_URL=http://unicorn:8080
-# path of hosted unicorn (with leading shlash)
+# path of hosted unicorn (with leading slash)
 UNICORN_DEPLOY_PATH=/unicorn
 
 # name of deployed unicorn under docker zoo deploy path (without any slashes)


### PR DESCRIPTION
In order to make the configuration independent from the specified URLs you can use the hostnames Docker Compose provides for communication between containers.

For detailed information see [Networking in Compose](https://docs.docker.com/compose/networking/)